### PR TITLE
Pegs igc version numebr to 0.2.20-puppeteer

### DIFF
--- a/charts/jenkins-config/templates/job.yaml
+++ b/charts/jenkins-config/templates/job.yaml
@@ -19,7 +19,7 @@ spec:
                 - name: jenkins-config
                   image: garagecatalyst/node11:latest
                   imagePullPolicy: IfNotPresent
-                  command: ["bash", "-c", "export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace); npm i -g @garage-catalyst/ibm-garage-cloud-cli@puppeteer && echo $NAMESPACE && ~/.npm-packages/bin/igc jenkins-auth --inCluster -n ${NAMESPACE}"]
+                  command: ["bash", "-c", "export NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace); npm i -g @garage-catalyst/ibm-garage-cloud-cli@0.2.20-puppeteer && echo $NAMESPACE && ~/.npm-packages/bin/igc jenkins-auth --inCluster -n ${NAMESPACE}"]
                   env:
                       - name: JENKINS_HOST
                         value: {{ .Values.jenkins.host | quote }}

--- a/jenkins-values.yaml
+++ b/jenkins-values.yaml
@@ -10,71 +10,44 @@
 
 master:
   testEnabled: false
-  componentName: jenkins-master
-  nodeSelector: {}
-  tolerations: {}
-  image: "jenkins/jenkins"
-  imageTag: "lts"
-  imagePullPolicy: "Always"
-  useSecurity: true
-  adminUser: admin
-  # AdminPassword: <defaults to random>
-  cpu: "200m"
-  memory: "256Mi"
-  serviceType: ClusterIP
-  servicePort: 80
-  targetPort: 8080
-  serviceAnnotations: {}
   # Enable Kubernetes Liveness and Readiness Probes
-  healthProbes: true
-  healthProbesTimeout: 60
-  slaveListenerPort: 50000
-  # List of plugins to be install during Jenkins master start
-  installPlugins:
-    - configuration-as-code
-    - kubernetes
+#  installPlugins:
+#    - kubernetes
+#    - kubernetes-credentials-provider
+#    - workflow-aggregator
+#    - workflow-job
+#    - credentials-binding
+#    - git
+#    - gitlab
+#    - greenballs
+#    - blueocean
+#    - job-dsl
+#    - oic-auth
+  additionalPlugins:
     - kubernetes-credentials-provider
-    - workflow-aggregator
-    - workflow-job
-    - credentials-binding
-    - git
     - gitlab
     - greenballs
     - blueocean
     - job-dsl
     - oic-auth
+#  overwritePlugins: false
+
+  # Configures if plugins bundled with `master.image` should be overwritten with the values of 'master.installPlugins' on upgrade or redeployment.
+#  overwritePluginsFromImage: false
+
   # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
-  scriptApproval:
-    - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
-    - "new groovy.json.JsonSlurperClassic"
-    - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map"
-    - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.lang.String"
-  customConfigMap: false
+#  scriptApproval:
+#    - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
+#    - "new groovy.json.JsonSlurperClassic"
+#    - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods leftShift java.util.Map java.util.Map"
+#    - "staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods split java.lang.String"
   ingress:
     enabled: true
     apiVersion: networking.k8s.io/v1beta1
   csrf:
     defaultCrumbIssuer:
-      enabled: false
+      enabled: true
       proxyCompatability: true
-
-agent:
-  enabled: true
-  image: jenkins/jnlp-slave
-  imageTag: latest
-  component: "jenkins-slave"
-  privileged: false
-  cpu: "200m"
-  memory: "256Mi"
-  # You may want to change this to true while testing a new image
-  alwaysPullImage: false
-  # You can define the volumes that you want to mount for this container
-  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
-  volumes:
-    - type: HostPath
-      hostPath: /var/run/docker.sock
-      mountPath: /var/run/docker.sock
-  nodeSelector: {}
 
 persistence:
   enabled: false
@@ -84,17 +57,6 @@ persistence:
   # ExistingClaim:
   ## jenkins data Persistent Volume Storage Class
   #storageClass: "ibmc-file-gold"
-
-  annotations: {}
-  accessMode: ReadWriteOnce
-  size: 20Gi
-  volumes:
-  #  - name: nothing
-  #    emptyDir: {}
-  mounts:
-  #  - mountPath: /var/nothing
-  #    name: nothing
-  #    readOnly: true
 
 rbac:
   create: true

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "storage_class" {
 variable "helm_version" {
   type        = string
   description = "The version of helm chart that should be deployed"
-  default     = "1.20.0"
+  default     = "2.0.1"
 }
 
 variable "server_url" {


### PR DESCRIPTION
- Pegs igc version numebr to 0.2.20-puppeteer
- Enable csrf and bumps helm chart to 2.0.1
- Removes values that repeat defaults (i.e. only set values that change defaults) in jenkins-values.yaml
- Moves custom plugins into `additionalPlugins` value in jeknins-values.yaml
- Removes scriptApproval value from jenkins-values.yaml
